### PR TITLE
change use_basic_auth to use_query_token

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,4 +13,4 @@ Imports:
     jsonlite
 Suggests:
     testthat
-RoxygenNote: 5.0.1
+RoxygenNote: 7.1.0

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: github
 Type: Package
 Title: github API
-Version: 0.9.11
+Version: 0.9.12
 Author: Carlos Scheidegger <cscheid@research.att.com>
 Maintainer: Simon Urbanek <urbanek@R-project.org>
 Description: Provides access to the Github v3 API

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,11 @@
+## rgithub 0.9.12
+* `use_basic_auth` is renamed `use_query_token` and has the opposite meaning and default (and it
+  is documented)
+
 ## rgithub 0.9.11
-* Using HTTP Basic Authentication is now an option `github.use.basic.auth` to `create.gist.context()`, default `FALSE` for compatibility with [https://github.com/att/rcloud-gist-services](rcloud-gist-services).
+* Using HTTP Basic Authentication is now an option `use_basic_auth` to
+  `create.gist.context()`, default `FALSE` for compatibility with
+  [https://github.com/att/rcloud-gist-services](rcloud-gist-services).
 
 ## rgithub 0.9.10
 * Uses HTTP Basic Authentication instead of passing `access_token` in query string (#1)

--- a/R/github.R
+++ b/R/github.R
@@ -107,11 +107,13 @@ interactive.login <- function(client_id = NULL,
 #'
 #' @param verbose if TRUE, passes verbose() to httr configuration
 #'
+#' @param use_query_token if TRUE, passes the access token in query string, otherwise in header
+#'
 #' @return a github context object that is used in every github API call
 #'   issued by this library.
 create.github.context <- function(api_url = "https://api.github.com", client_id = NULL,
                                   client_secret = NULL, access_token = NULL, personal_token = NULL,
-                                  max_etags = 10000, verbose = FALSE, use_basic_auth = FALSE)
+                                  max_etags = 10000, verbose = FALSE, use_query_token = TRUE)
 {
   if (is.null(personal_token) && (Sys.getenv("GITHUB_PAT") != "")) {
     personal_token <- Sys.getenv("GITHUB_PAT")
@@ -125,7 +127,7 @@ create.github.context <- function(api_url = "https://api.github.com", client_id 
               etags          = new.env(parent = emptyenv()),
               authenticated  = !is.null(access_token),
               verbose        = verbose,
-              use_basic_auth = use_basic_auth)
+              use_query_token = use_query_token)
   if (!is.null(access_token) || !is.null(personal_token)) {
     r <- get.myself(ctx)
     if (!r$ok) {
@@ -196,7 +198,7 @@ get.github.context <- function()
     # old-style: was just a query parameter - now deprecated
     # in favor of Authorization: token XXX header
     config <- c()
-    if(!ctx$use_basic_auth) {
+    if(ctx$use_query_token) {
       query$access_token <- ctx$token
     } else {
       config <- c(add_headers(Authorization=paste("token", ctx$token)))

--- a/man/add.emails.Rd
+++ b/man/add.emails.Rd
@@ -17,4 +17,3 @@ The new list of emails
 \description{
 Add emails to the account
 }
-

--- a/man/add.issue.labels.Rd
+++ b/man/add.issue.labels.Rd
@@ -4,8 +4,13 @@
 \alias{add.issue.labels}
 \title{Add labels to an issue}
 \usage{
-add.issue.labels(owner, repo, issue.number, content,
-  ctx = get.github.context())
+add.issue.labels(
+  owner,
+  repo,
+  issue.number,
+  content,
+  ctx = get.github.context()
+)
 }
 \arguments{
 \item{owner}{the repo owner}
@@ -24,4 +29,3 @@ The list of labels
 \description{
 Add labels to an issue
 }
-

--- a/man/add.member.to.team.Rd
+++ b/man/add.member.to.team.Rd
@@ -19,4 +19,3 @@ TRUE if user is member of team
 \description{
 add member to team
 }
-

--- a/man/add.repository.collaborator.Rd
+++ b/man/add.repository.collaborator.Rd
@@ -21,4 +21,3 @@ none
 \description{
 add a user to the list of collaborators of a repo
 }
-

--- a/man/add.repository.to.team.Rd
+++ b/man/add.repository.to.team.Rd
@@ -21,4 +21,3 @@ none
 \description{
 add repository to team
 }
-

--- a/man/am.following.user.Rd
+++ b/man/am.following.user.Rd
@@ -17,4 +17,3 @@ TRUE or FALSE
 \description{
 Test whether current user is following given user
 }
-

--- a/man/conceal.member.of.organization.Rd
+++ b/man/conceal.member.of.organization.Rd
@@ -19,4 +19,3 @@ None
 \description{
 conceal user membership in an organization
 }
-

--- a/man/create.blob.Rd
+++ b/man/create.blob.Rd
@@ -21,4 +21,3 @@ the blob
 \description{
 create a blob
 }
-

--- a/man/create.commit.Rd
+++ b/man/create.commit.Rd
@@ -21,4 +21,3 @@ the commit
 \description{
 create a commit
 }
-

--- a/man/create.commit.comment.Rd
+++ b/man/create.commit.comment.Rd
@@ -23,4 +23,3 @@ the comment
 \description{
 create a comment for a given commit in a repository
 }
-

--- a/man/create.fork.Rd
+++ b/man/create.fork.Rd
@@ -21,4 +21,3 @@ the new fork. Notice that forks happen asynchronously, so git objects will not b
 \description{
 create a fork under the current user
 }
-

--- a/man/create.gist.Rd
+++ b/man/create.gist.Rd
@@ -17,4 +17,3 @@ the new gist
 \description{
 create a new gist
 }
-

--- a/man/create.gist.comment.Rd
+++ b/man/create.gist.comment.Rd
@@ -19,4 +19,3 @@ the comment
 \description{
 Create gist comment
 }
-

--- a/man/create.github.context.Rd
+++ b/man/create.github.context.Rd
@@ -4,9 +4,16 @@
 \alias{create.github.context}
 \title{Create a github context object.}
 \usage{
-create.github.context(api_url = "https://api.github.com", client_id = NULL,
-  client_secret = NULL, access_token = NULL, personal_token = NULL,
-  max_etags = 10000, verbose = FALSE)
+create.github.context(
+  api_url = "https://api.github.com",
+  client_id = NULL,
+  client_secret = NULL,
+  access_token = NULL,
+  personal_token = NULL,
+  max_etags = 10000,
+  verbose = FALSE,
+  use_query_token = TRUE
+)
 }
 \arguments{
 \item{api_url}{the base URL}
@@ -22,6 +29,8 @@ create.github.context(api_url = "https://api.github.com", client_id = NULL,
 \item{max_etags}{the maximum number of entries to cache in the context}
 
 \item{verbose}{if TRUE, passes verbose() to httr configuration}
+
+\item{use_query_token}{if TRUE, passes the access token in query string, otherwise in header}
 }
 \value{
 a github context object that is used in every github API call
@@ -43,4 +52,3 @@ If any of the github API functions are called without a context, this
 context is used instead. (if no context has been created, an unauthenticated
 context will be created)
 }
-

--- a/man/create.hook.Rd
+++ b/man/create.hook.Rd
@@ -21,4 +21,3 @@ the specific hook
 \description{
 create a new hook for repo
 }
-

--- a/man/create.issue.Rd
+++ b/man/create.issue.Rd
@@ -21,4 +21,3 @@ the list of issues
 \description{
 Create issue
 }
-

--- a/man/create.issue.comment.Rd
+++ b/man/create.issue.comment.Rd
@@ -4,8 +4,13 @@
 \alias{create.issue.comment}
 \title{Create issue comment}
 \usage{
-create.issue.comment(owner, repo, issue.number, content,
-  ctx = get.github.context())
+create.issue.comment(
+  owner,
+  repo,
+  issue.number,
+  content,
+  ctx = get.github.context()
+)
 }
 \arguments{
 \item{owner}{the repo owner}
@@ -24,4 +29,3 @@ the comment
 \description{
 Create issue comment
 }
-

--- a/man/create.key.Rd
+++ b/man/create.key.Rd
@@ -17,4 +17,3 @@ the added public key
 \description{
 Add a public key with some id
 }
-

--- a/man/create.milestone.Rd
+++ b/man/create.milestone.Rd
@@ -21,4 +21,3 @@ the created milestone
 \description{
 Create milestone
 }
-

--- a/man/create.organization.repository.Rd
+++ b/man/create.organization.repository.Rd
@@ -20,4 +20,3 @@ the created repository
 \description{
 create rpository under given organization
 }
-

--- a/man/create.pull.request.Rd
+++ b/man/create.pull.request.Rd
@@ -21,4 +21,3 @@ the specific pull request
 \description{
 create a pull request
 }
-

--- a/man/create.pull.request.comment.Rd
+++ b/man/create.pull.request.comment.Rd
@@ -4,8 +4,13 @@
 \alias{create.pull.request.comment}
 \title{Create a comment on a pull request}
 \usage{
-create.pull.request.comment(owner, repo, pull.id, content,
-  ctx = get.github.context())
+create.pull.request.comment(
+  owner,
+  repo,
+  pull.id,
+  content,
+  ctx = get.github.context()
+)
 }
 \arguments{
 \item{owner}{the repo owner}
@@ -24,4 +29,3 @@ the comment
 \description{
 Create a comment on a pull request
 }
-

--- a/man/create.reference.Rd
+++ b/man/create.reference.Rd
@@ -21,4 +21,3 @@ the created reference
 \description{
 create a reference
 }
-

--- a/man/create.repository.Rd
+++ b/man/create.repository.Rd
@@ -18,4 +18,3 @@ the created repository
 \description{
 create repository
 }
-

--- a/man/create.repository.key.Rd
+++ b/man/create.repository.key.Rd
@@ -21,4 +21,3 @@ the key
 \description{
 create a repository key
 }
-

--- a/man/create.repository.label.Rd
+++ b/man/create.repository.label.Rd
@@ -21,4 +21,3 @@ The given label
 \description{
 create a label for a repository
 }
-

--- a/man/create.repository.status.Rd
+++ b/man/create.repository.status.Rd
@@ -23,4 +23,3 @@ the list of statuses
 \description{
 create status for a ref in a repo
 }
-

--- a/man/create.tag.Rd
+++ b/man/create.tag.Rd
@@ -21,4 +21,3 @@ the tag
 \description{
 create a tag
 }
-

--- a/man/create.team.Rd
+++ b/man/create.team.Rd
@@ -19,4 +19,3 @@ team information
 \description{
 create a team in an organization
 }
-

--- a/man/create.tree.Rd
+++ b/man/create.tree.Rd
@@ -21,4 +21,3 @@ the tree contents
 \description{
 get a tree
 }
-

--- a/man/delete.all.issue.labels.Rd
+++ b/man/delete.all.issue.labels.Rd
@@ -21,4 +21,3 @@ None
 \description{
 Delete all issue labels
 }
-

--- a/man/delete.commit.comment.Rd
+++ b/man/delete.commit.comment.Rd
@@ -21,4 +21,3 @@ none
 \description{
 delete a single commit comment
 }
-

--- a/man/delete.emails.Rd
+++ b/man/delete.emails.Rd
@@ -17,4 +17,3 @@ Nothing
 \description{
 Delete emails from the account
 }
-

--- a/man/delete.gist.Rd
+++ b/man/delete.gist.Rd
@@ -17,4 +17,3 @@ none
 \description{
 delete a gist
 }
-

--- a/man/delete.gist.comment.Rd
+++ b/man/delete.gist.comment.Rd
@@ -19,4 +19,3 @@ none
 \description{
 Delete gist comment
 }
-

--- a/man/delete.hook.Rd
+++ b/man/delete.hook.Rd
@@ -21,4 +21,3 @@ none
 \description{
 delete a hook.
 }
-

--- a/man/delete.issue.comment.Rd
+++ b/man/delete.issue.comment.Rd
@@ -4,8 +4,13 @@
 \alias{delete.issue.comment}
 \title{Delete issue comment}
 \usage{
-delete.issue.comment(owner, repo, issue.number, comment.number,
-  ctx = get.github.context())
+delete.issue.comment(
+  owner,
+  repo,
+  issue.number,
+  comment.number,
+  ctx = get.github.context()
+)
 }
 \arguments{
 \item{owner}{the repo owner}
@@ -24,4 +29,3 @@ None
 \description{
 Delete issue comment
 }
-

--- a/man/delete.issue.label.Rd
+++ b/man/delete.issue.label.Rd
@@ -4,8 +4,7 @@
 \alias{delete.issue.label}
 \title{Delete an issue from a label}
 \usage{
-delete.issue.label(owner, repo, issue.number, name,
-  ctx = get.github.context())
+delete.issue.label(owner, repo, issue.number, name, ctx = get.github.context())
 }
 \arguments{
 \item{owner}{the repo owner}
@@ -24,4 +23,3 @@ None
 \description{
 Delete an issue from a label
 }
-

--- a/man/delete.key.Rd
+++ b/man/delete.key.Rd
@@ -17,4 +17,3 @@ None
 \description{
 Delete a public key with some id
 }
-

--- a/man/delete.member.from.organization.Rd
+++ b/man/delete.member.from.organization.Rd
@@ -19,4 +19,3 @@ none
 \description{
 delete user from an organization
 }
-

--- a/man/delete.member.from.team.Rd
+++ b/man/delete.member.from.team.Rd
@@ -19,4 +19,3 @@ none
 \description{
 remove member from team
 }
-

--- a/man/delete.milestone.Rd
+++ b/man/delete.milestone.Rd
@@ -21,4 +21,3 @@ None
 \description{
 Delete milestone
 }
-

--- a/man/delete.pull.request.comment.Rd
+++ b/man/delete.pull.request.comment.Rd
@@ -4,8 +4,12 @@
 \alias{delete.pull.request.comment}
 \title{Delete a comment on a pull request}
 \usage{
-delete.pull.request.comment(owner, repo, comment.id,
-  ctx = get.github.context())
+delete.pull.request.comment(
+  owner,
+  repo,
+  comment.id,
+  ctx = get.github.context()
+)
 }
 \arguments{
 \item{owner}{the repo owner}
@@ -22,4 +26,3 @@ the comment
 \description{
 Delete a comment on a pull request
 }
-

--- a/man/delete.reference.Rd
+++ b/man/delete.reference.Rd
@@ -21,4 +21,3 @@ none
 \description{
 delete a reference
 }
-

--- a/man/delete.repository.Rd
+++ b/man/delete.repository.Rd
@@ -19,4 +19,3 @@ nothing
 \description{
 delete repository
 }
-

--- a/man/delete.repository.collaborator.Rd
+++ b/man/delete.repository.collaborator.Rd
@@ -21,4 +21,3 @@ none
 \description{
 delete a user from the list of collaborators of a repo
 }
-

--- a/man/delete.repository.download.Rd
+++ b/man/delete.repository.download.Rd
@@ -21,4 +21,3 @@ the specific downloads
 \description{
 delete specific download for a repository
 }
-

--- a/man/delete.repository.from.team.Rd
+++ b/man/delete.repository.from.team.Rd
@@ -21,4 +21,3 @@ none
 \description{
 remove repository from team
 }
-

--- a/man/delete.repository.key.Rd
+++ b/man/delete.repository.key.Rd
@@ -21,4 +21,3 @@ none
 \description{
 delete a repository key
 }
-

--- a/man/delete.repository.label.Rd
+++ b/man/delete.repository.label.Rd
@@ -21,4 +21,3 @@ None
 \description{
 delete a label from a repository
 }
-

--- a/man/delete.repository.path.Rd
+++ b/man/delete.repository.path.Rd
@@ -23,4 +23,3 @@ the file
 \description{
 Delete a file in a repository
 }
-

--- a/man/delete.team.Rd
+++ b/man/delete.team.Rd
@@ -17,4 +17,3 @@ none
 \description{
 delete a team in an organization
 }
-

--- a/man/follow.user.Rd
+++ b/man/follow.user.Rd
@@ -17,4 +17,3 @@ none
 \description{
 Start following a given user
 }
-

--- a/man/fork.gist.Rd
+++ b/man/fork.gist.Rd
@@ -17,4 +17,3 @@ the new gist
 \description{
 fork a gist
 }
-

--- a/man/get.all.my.issues.Rd
+++ b/man/get.all.my.issues.Rd
@@ -17,4 +17,3 @@ the list of issues
 \description{
 get all issues across all the authenticated user's visible repositories including owned repositories, member repositories, and organization repositories
 }
-

--- a/man/get.all.references.Rd
+++ b/man/get.all.references.Rd
@@ -4,8 +4,12 @@
 \alias{get.all.references}
 \title{get all references (or subreferences)}
 \usage{
-get.all.references(owner, repo, subnamespace = NULL,
-  ctx = get.github.context())
+get.all.references(
+  owner,
+  repo,
+  subnamespace = NULL,
+  ctx = get.github.context()
+)
 }
 \arguments{
 \item{owner}{the repo owner}
@@ -22,4 +26,3 @@ the list of references
 \description{
 get all references (or subreferences)
 }
-

--- a/man/get.all.repositories.Rd
+++ b/man/get.all.repositories.Rd
@@ -17,4 +17,3 @@ list of repositories
 \description{
 get list of all repositories
 }
-

--- a/man/get.all.repository.issues.comments.Rd
+++ b/man/get.all.repository.issues.comments.Rd
@@ -4,8 +4,12 @@
 \alias{get.all.repository.issues.comments}
 \title{Get list of comments for an issue}
 \usage{
-get.all.repository.issues.comments(owner, repo, ...,
-  ctx = get.github.context())
+get.all.repository.issues.comments(
+  owner,
+  repo,
+  ...,
+  ctx = get.github.context()
+)
 }
 \arguments{
 \item{owner}{the repo owner}
@@ -22,4 +26,3 @@ the list of comments
 \description{
 Get list of comments for an issue
 }
-

--- a/man/get.assignees.Rd
+++ b/man/get.assignees.Rd
@@ -19,4 +19,3 @@ the list of assignees
 \description{
 Get list of assignees for a repo
 }
-

--- a/man/get.blob.Rd
+++ b/man/get.blob.Rd
@@ -21,4 +21,3 @@ the blob
 \description{
 get a blob
 }
-

--- a/man/get.commit.Rd
+++ b/man/get.commit.Rd
@@ -21,4 +21,3 @@ the commit
 \description{
 get a commit
 }
-

--- a/man/get.commit.comment.Rd
+++ b/man/get.commit.comment.Rd
@@ -21,4 +21,3 @@ the comment
 \description{
 get a single commit comment
 }
-

--- a/man/get.gist.Rd
+++ b/man/get.gist.Rd
@@ -19,4 +19,3 @@ the specific gist
 \description{
 get a specific gist
 }
-

--- a/man/get.gist.comment.Rd
+++ b/man/get.gist.comment.Rd
@@ -19,4 +19,3 @@ the comment
 \description{
 Get specific comment
 }
-

--- a/man/get.gist.comments.Rd
+++ b/man/get.gist.comments.Rd
@@ -17,4 +17,3 @@ the list of comments
 \description{
 Get comments for a gist
 }
-

--- a/man/get.gist.forks.Rd
+++ b/man/get.gist.forks.Rd
@@ -17,4 +17,3 @@ the list of fork information
 \description{
 list the forks of a gist
 }
-

--- a/man/get.github.context.Rd
+++ b/man/get.github.context.Rd
@@ -12,4 +12,3 @@ a github context object
 \description{
 returns the most recently created github context, or creates one if none has been so far created
 }
-

--- a/man/get.issue.comment.Rd
+++ b/man/get.issue.comment.Rd
@@ -4,8 +4,13 @@
 \alias{get.issue.comment}
 \title{Get specific comment}
 \usage{
-get.issue.comment(owner, repo, issue.number, comment.number,
-  ctx = get.github.context())
+get.issue.comment(
+  owner,
+  repo,
+  issue.number,
+  comment.number,
+  ctx = get.github.context()
+)
 }
 \arguments{
 \item{owner}{the repo owner}
@@ -24,4 +29,3 @@ the comment
 \description{
 Get specific comment
 }
-

--- a/man/get.issue.comments.Rd
+++ b/man/get.issue.comments.Rd
@@ -21,4 +21,3 @@ the list of comments
 \description{
 Get list of comments for an issue
 }
-

--- a/man/get.issue.events.Rd
+++ b/man/get.issue.events.Rd
@@ -21,4 +21,3 @@ The event list
 \description{
 List events for an issue
 }
-

--- a/man/get.issue.labels.Rd
+++ b/man/get.issue.labels.Rd
@@ -21,4 +21,3 @@ The list of labels
 \description{
 List all labels for an issue
 }
-

--- a/man/get.key.Rd
+++ b/man/get.key.Rd
@@ -17,4 +17,3 @@ the public key
 \description{
 Get a public key with some id
 }
-

--- a/man/get.milestone.Rd
+++ b/man/get.milestone.Rd
@@ -21,4 +21,3 @@ the milestone list
 \description{
 Get specific milestone from a repository
 }
-

--- a/man/get.milestone.labels.Rd
+++ b/man/get.milestone.labels.Rd
@@ -4,8 +4,7 @@
 \alias{get.milestone.labels}
 \title{Get labels for every issue in a milestone}
 \usage{
-get.milestone.labels(owner, repo, milestone.number,
-  ctx = get.github.context())
+get.milestone.labels(owner, repo, milestone.number, ctx = get.github.context())
 }
 \arguments{
 \item{owner}{the repo owner}
@@ -22,4 +21,3 @@ All labels for that milestone
 \description{
 Get labels for every issue in a milestone
 }
-

--- a/man/get.milestones.Rd
+++ b/man/get.milestones.Rd
@@ -21,4 +21,3 @@ the milestone list
 \description{
 List milestones for a repository
 }
-

--- a/man/get.my.emails.Rd
+++ b/man/get.my.emails.Rd
@@ -15,4 +15,3 @@ A list of emails
 \description{
 Get the list of emails of the current user
 }
-

--- a/man/get.my.followers.Rd
+++ b/man/get.my.followers.Rd
@@ -15,4 +15,3 @@ the list of followers
 \description{
 Get the list of followers for the current user
 }
-

--- a/man/get.my.following.Rd
+++ b/man/get.my.following.Rd
@@ -15,4 +15,3 @@ the list of followers
 \description{
 List who is following the current user
 }
-

--- a/man/get.my.gists.Rd
+++ b/man/get.my.gists.Rd
@@ -15,4 +15,3 @@ the list of gists
 \description{
 list the current user's gists
 }
-

--- a/man/get.my.issues.Rd
+++ b/man/get.my.issues.Rd
@@ -17,4 +17,3 @@ the list of issues
 \description{
 List all issues across owned and member repositories for the authenticated user:
 }
-

--- a/man/get.my.keys.Rd
+++ b/man/get.my.keys.Rd
@@ -15,4 +15,3 @@ list of keys
 \description{
 Get public keys for the current user
 }
-

--- a/man/get.my.notifications.Rd
+++ b/man/get.my.notifications.Rd
@@ -17,4 +17,3 @@ the list of notifications
 \description{
 list the current user's notifications
 }
-

--- a/man/get.my.organization.events.Rd
+++ b/man/get.my.organization.events.Rd
@@ -19,4 +19,3 @@ the list of events
 \description{
 list events from the authenticated user organization
 }
-

--- a/man/get.my.organizations.Rd
+++ b/man/get.my.organizations.Rd
@@ -15,4 +15,3 @@ the list of organizations
 \description{
 List all organizations for the current user.
 }
-

--- a/man/get.my.repositories.Rd
+++ b/man/get.my.repositories.Rd
@@ -17,4 +17,3 @@ list of repositories
 \description{
 Get list of repositories of current user
 }
-

--- a/man/get.my.repository.notifications.Rd
+++ b/man/get.my.repository.notifications.Rd
@@ -21,4 +21,3 @@ the list of notifications
 \description{
 list the current user's notifications for a given repo
 }
-

--- a/man/get.myself.Rd
+++ b/man/get.myself.Rd
@@ -15,4 +15,3 @@ Information about the user
 \description{
 Get information on the current user
 }
-

--- a/man/get.network.public.events.Rd
+++ b/man/get.network.public.events.Rd
@@ -21,4 +21,3 @@ the list of events for the network of repositories
 \description{
 list events for a network of repositories
 }
-

--- a/man/get.organization.Rd
+++ b/man/get.organization.Rd
@@ -17,4 +17,3 @@ the organization information
 \description{
 Get an organization
 }
-

--- a/man/get.organization.issues.Rd
+++ b/man/get.organization.issues.Rd
@@ -19,4 +19,3 @@ the list of issues
 \description{
 List all issues across an organization of the authenticated user:
 }
-

--- a/man/get.organization.members.Rd
+++ b/man/get.organization.members.Rd
@@ -17,4 +17,3 @@ the member list
 \description{
 list all members from an organization. List all users who are members of an organization. A member is a user that belongs to at least 1 team in the organization. If the authenticated user is also an owner of this organization then both concealed and public members will be returned. If the requester is not an owner of the organization the query will be redirected to the public members list.
 }
-

--- a/man/get.organization.public.events.Rd
+++ b/man/get.organization.public.events.Rd
@@ -19,4 +19,3 @@ the list of events for the network of repositories
 \description{
 list public events for an organization
 }
-

--- a/man/get.organization.public.members.Rd
+++ b/man/get.organization.public.members.Rd
@@ -17,4 +17,3 @@ the list of public members
 \description{
 list public members of organization
 }
-

--- a/man/get.organization.repositories.Rd
+++ b/man/get.organization.repositories.Rd
@@ -19,4 +19,3 @@ list of repositories
 \description{
 get list of repositories of given organization
 }
-

--- a/man/get.organization.teams.Rd
+++ b/man/get.organization.teams.Rd
@@ -17,4 +17,3 @@ the list of organization teams
 \description{
 list teams from an organization
 }
-

--- a/man/get.public.events.Rd
+++ b/man/get.public.events.Rd
@@ -17,4 +17,3 @@ the list of public events
 \description{
 list public events
 }
-

--- a/man/get.pull.request.Rd
+++ b/man/get.pull.request.Rd
@@ -21,4 +21,3 @@ the specific pull request
 \description{
 get a specific pull request
 }
-

--- a/man/get.pull.request.comments.Rd
+++ b/man/get.pull.request.comments.Rd
@@ -21,4 +21,3 @@ the list of comments for the pull request
 \description{
 List comments on a pull request
 }
-

--- a/man/get.pull.request.commits.Rd
+++ b/man/get.pull.request.commits.Rd
@@ -24,4 +24,3 @@ the list of pull request commits
 \description{
 list commits for a pull request
 }
-

--- a/man/get.pull.request.files.Rd
+++ b/man/get.pull.request.files.Rd
@@ -24,4 +24,3 @@ the list of pull request files
 \description{
 list files for a pull request
 }
-

--- a/man/get.pull.requests.Rd
+++ b/man/get.pull.requests.Rd
@@ -21,4 +21,3 @@ the list of pull requests
 \description{
 list all pull requests
 }
-

--- a/man/get.pull.requests.comment.Rd
+++ b/man/get.pull.requests.comment.Rd
@@ -21,4 +21,3 @@ the comment
 \description{
 Get specific comment for a pull request
 }
-

--- a/man/get.pull.requests.comments.Rd
+++ b/man/get.pull.requests.comments.Rd
@@ -21,4 +21,3 @@ the list of comments for the pull request
 \description{
 List comments on all pull requests for a repo
 }
-

--- a/man/get.reference.Rd
+++ b/man/get.reference.Rd
@@ -21,4 +21,3 @@ the reference
 \description{
 get a git reference
 }
-

--- a/man/get.repositories.starred.by.me.Rd
+++ b/man/get.repositories.starred.by.me.Rd
@@ -17,4 +17,3 @@ repo list
 \description{
 list repos starred by current user
 }
-

--- a/man/get.repositories.starred.by.user.Rd
+++ b/man/get.repositories.starred.by.user.Rd
@@ -19,4 +19,3 @@ repo list
 \description{
 list repos starred by user
 }
-

--- a/man/get.repositories.watched.by.me.Rd
+++ b/man/get.repositories.watched.by.me.Rd
@@ -15,4 +15,3 @@ list of repositories
 \description{
 list repos watched by current user
 }
-

--- a/man/get.repositories.watched.by.user.Rd
+++ b/man/get.repositories.watched.by.user.Rd
@@ -17,4 +17,3 @@ list of repositories
 \description{
 list repos watched by users
 }
-

--- a/man/get.repository.Rd
+++ b/man/get.repository.Rd
@@ -19,4 +19,3 @@ the repository
 \description{
 get repository
 }
-

--- a/man/get.repository.archive.Rd
+++ b/man/get.repository.archive.Rd
@@ -23,4 +23,3 @@ the archive
 \description{
 Get the archive of a repo
 }
-

--- a/man/get.repository.branch.Rd
+++ b/man/get.repository.branch.Rd
@@ -21,4 +21,3 @@ information about the branch
 \description{
 get specific repository branch
 }
-

--- a/man/get.repository.branches.Rd
+++ b/man/get.repository.branches.Rd
@@ -19,4 +19,3 @@ list of branches
 \description{
 get list of repository branches
 }
-

--- a/man/get.repository.collaborators.Rd
+++ b/man/get.repository.collaborators.Rd
@@ -19,4 +19,3 @@ list of collaborators
 \description{
 get list of collaborators of a repo
 }
-

--- a/man/get.repository.comments.Rd
+++ b/man/get.repository.comments.Rd
@@ -19,4 +19,3 @@ list of comments
 \description{
 get all commit comments for a repository
 }
-

--- a/man/get.repository.commit.Rd
+++ b/man/get.repository.commit.Rd
@@ -21,4 +21,3 @@ the commit
 \description{
 get a specific commit from a repo
 }
-

--- a/man/get.repository.commit.comments.Rd
+++ b/man/get.repository.commit.comments.Rd
@@ -21,4 +21,3 @@ the comments
 \description{
 get all commit comments for a given commit in a repository
 }
-

--- a/man/get.repository.commits.Rd
+++ b/man/get.repository.commits.Rd
@@ -21,4 +21,3 @@ list of commits
 \description{
 get commits from a repo
 }
-

--- a/man/get.repository.contributors.Rd
+++ b/man/get.repository.contributors.Rd
@@ -19,4 +19,3 @@ list of repo contributors
 \description{
 get list of repository contributors
 }
-

--- a/man/get.repository.contributors.stats.Rd
+++ b/man/get.repository.contributors.stats.Rd
@@ -19,4 +19,3 @@ list of repo contributors stats
 \description{
 get stats on repository contributors
 }
-

--- a/man/get.repository.diff.Rd
+++ b/man/get.repository.diff.Rd
@@ -23,4 +23,3 @@ the commit
 \description{
 return a diff between two commits
 }
-

--- a/man/get.repository.download.Rd
+++ b/man/get.repository.download.Rd
@@ -21,4 +21,3 @@ the specific downloads
 \description{
 get specific download for a repository
 }
-

--- a/man/get.repository.downloads.Rd
+++ b/man/get.repository.downloads.Rd
@@ -19,4 +19,3 @@ the list of downloads
 \description{
 list downloads for a repository
 }
-

--- a/man/get.repository.events.Rd
+++ b/man/get.repository.events.Rd
@@ -21,4 +21,3 @@ the list of repository events
 \description{
 list events for a given repo
 }
-

--- a/man/get.repository.forks.Rd
+++ b/man/get.repository.forks.Rd
@@ -21,4 +21,3 @@ the list of forks
 \description{
 list forks
 }
-

--- a/man/get.repository.hook.Rd
+++ b/man/get.repository.hook.Rd
@@ -21,4 +21,3 @@ the specific hook
 \description{
 get specific hook of repository
 }
-

--- a/man/get.repository.hooks.Rd
+++ b/man/get.repository.hooks.Rd
@@ -19,4 +19,3 @@ list of hooks
 \description{
 list hooks of repository
 }
-

--- a/man/get.repository.issue.event.Rd
+++ b/man/get.repository.issue.event.Rd
@@ -4,8 +4,12 @@
 \alias{get.repository.issue.event}
 \title{List a single event for a repository issue}
 \usage{
-get.repository.issue.event(owner, repo, event.number,
-  ctx = get.github.context())
+get.repository.issue.event(
+  owner,
+  repo,
+  event.number,
+  ctx = get.github.context()
+)
 }
 \arguments{
 \item{owner}{the repo owner}
@@ -22,4 +26,3 @@ The chosen event
 \description{
 List a single event for a repository issue
 }
-

--- a/man/get.repository.issue.events.Rd
+++ b/man/get.repository.issue.events.Rd
@@ -21,4 +21,3 @@ the list of repository issue events
 \description{
 list issue events for a given repo
 }
-

--- a/man/get.repository.issues.Rd
+++ b/man/get.repository.issues.Rd
@@ -21,4 +21,3 @@ the list of issues
 \description{
 List all issues for a repo
 }
-

--- a/man/get.repository.key.Rd
+++ b/man/get.repository.key.Rd
@@ -21,4 +21,3 @@ the key
 \description{
 get a specific repository key
 }
-

--- a/man/get.repository.keys.Rd
+++ b/man/get.repository.keys.Rd
@@ -19,4 +19,3 @@ the key list
 \description{
 list all repository keys
 }
-

--- a/man/get.repository.label.Rd
+++ b/man/get.repository.label.Rd
@@ -21,4 +21,3 @@ The given label
 \description{
 get a specific label for a repository
 }
-

--- a/man/get.repository.labels.Rd
+++ b/man/get.repository.labels.Rd
@@ -19,4 +19,3 @@ The list of labels
 \description{
 List all labels for a repository
 }
-

--- a/man/get.repository.languages.Rd
+++ b/man/get.repository.languages.Rd
@@ -19,4 +19,3 @@ list of languages
 \description{
 get list of languages used in the repository, as estimated by github
 }
-

--- a/man/get.repository.path.Rd
+++ b/man/get.repository.path.Rd
@@ -23,4 +23,3 @@ the file
 \description{
 Get the contents of a file
 }
-

--- a/man/get.repository.readme.Rd
+++ b/man/get.repository.readme.Rd
@@ -21,4 +21,3 @@ the readme
 \description{
 Get the README for a repo
 }
-

--- a/man/get.repository.status.Rd
+++ b/man/get.repository.status.Rd
@@ -21,4 +21,3 @@ the combined status
 \description{
 get combined status for a ref in a repo
 }
-

--- a/man/get.repository.statuses.Rd
+++ b/man/get.repository.statuses.Rd
@@ -21,4 +21,3 @@ the list of statuses
 \description{
 get statuses for a ref in a repo
 }
-

--- a/man/get.repository.subscription.Rd
+++ b/man/get.repository.subscription.Rd
@@ -19,4 +19,3 @@ subscription info
 \description{
 get repository subscription info
 }
-

--- a/man/get.repository.tags.Rd
+++ b/man/get.repository.tags.Rd
@@ -19,4 +19,3 @@ list of tags
 \description{
 get list of repository tags
 }
-

--- a/man/get.repository.teams.Rd
+++ b/man/get.repository.teams.Rd
@@ -19,4 +19,3 @@ list of teams
 \description{
 get list of teams participating in the repository
 }
-

--- a/man/get.stargazers.Rd
+++ b/man/get.stargazers.Rd
@@ -19,4 +19,3 @@ user list
 \description{
 list people who starred a repo
 }
-

--- a/man/get.tag.Rd
+++ b/man/get.tag.Rd
@@ -21,4 +21,3 @@ the tag
 \description{
 get a tag
 }
-

--- a/man/get.team.Rd
+++ b/man/get.team.Rd
@@ -17,4 +17,3 @@ team information
 \description{
 get team information
 }
-

--- a/man/get.team.members.Rd
+++ b/man/get.team.members.Rd
@@ -17,4 +17,3 @@ team member list
 \description{
 list team members
 }
-

--- a/man/get.team.repositories.Rd
+++ b/man/get.team.repositories.Rd
@@ -17,4 +17,3 @@ the repository list
 \description{
 list repositories of a team
 }
-

--- a/man/get.thread.notifications.Rd
+++ b/man/get.thread.notifications.Rd
@@ -17,4 +17,3 @@ the thread
 \description{
 get single thread notifications
 }
-

--- a/man/get.thread.notifications.subscription.Rd
+++ b/man/get.thread.notifications.subscription.Rd
@@ -17,4 +17,3 @@ the response object
 \description{
 checks to see if the current user is subscribed to a thread.
 }
-

--- a/man/get.tree.Rd
+++ b/man/get.tree.Rd
@@ -23,4 +23,3 @@ the tree contents
 \description{
 get a tree
 }
-

--- a/man/get.user.Rd
+++ b/man/get.user.Rd
@@ -17,4 +17,3 @@ Information about the user
 \description{
 Get information on some user
 }
-

--- a/man/get.user.followers.Rd
+++ b/man/get.user.followers.Rd
@@ -17,4 +17,3 @@ the list of followers
 \description{
 Get the list of followers for a given user
 }
-

--- a/man/get.user.following.Rd
+++ b/man/get.user.following.Rd
@@ -17,4 +17,3 @@ the list of followers
 \description{
 List who a user is following
 }
-

--- a/man/get.user.gists.Rd
+++ b/man/get.user.gists.Rd
@@ -17,4 +17,3 @@ the list of gists
 \description{
 list the gists of a given user
 }
-

--- a/man/get.user.keys.Rd
+++ b/man/get.user.keys.Rd
@@ -17,4 +17,3 @@ list of keys
 \description{
 Get public keys for a given user
 }
-

--- a/man/get.user.organizations.Rd
+++ b/man/get.user.organizations.Rd
@@ -17,4 +17,3 @@ the list of organizations
 \description{
 List all public organizations for an unauthenticated user. Lists private and public organizations for authenticated users.
 }
-

--- a/man/get.user.performed.events.Rd
+++ b/man/get.user.performed.events.Rd
@@ -20,4 +20,3 @@ the list of events the user has performed. If user is the authenticated user,
 \description{
 list events that a user has performed
 }
-

--- a/man/get.user.public.performed.events.Rd
+++ b/man/get.user.public.performed.events.Rd
@@ -19,4 +19,3 @@ the list of public events the user has performed.
 \description{
 list public events that a user has performed
 }
-

--- a/man/get.user.public.received.events.Rd
+++ b/man/get.user.public.received.events.Rd
@@ -19,4 +19,3 @@ the list of public events the user has received
 \description{
 list public events that a user has received
 }
-

--- a/man/get.user.received.events.Rd
+++ b/man/get.user.received.events.Rd
@@ -19,4 +19,3 @@ the list of events the user has received
 \description{
 list events that a user has received
 }
-

--- a/man/get.user.repositories.Rd
+++ b/man/get.user.repositories.Rd
@@ -19,4 +19,3 @@ list of repositories
 \description{
 Get list of repositories of given user
 }
-

--- a/man/get.users.Rd
+++ b/man/get.users.Rd
@@ -17,4 +17,3 @@ A list of users
 \description{
 Get all github users
 }
-

--- a/man/get.watchers.Rd
+++ b/man/get.watchers.Rd
@@ -19,4 +19,3 @@ list of repository watchers
 \description{
 list repo watchers
 }
-

--- a/man/github.Rd
+++ b/man/github.Rd
@@ -3,7 +3,6 @@
 \docType{package}
 \name{github}
 \alias{github}
-\alias{github-package}
 \title{github-package: use the Github API from R}
 \description{
 This package wraps the Github web service API so you can make R
@@ -13,12 +12,11 @@ This package wraps the Github web service API so you can make R
 \examples{
 \dontrun{get.user.repositories("cscheid")}
 }
-\author{
-Carlos Scheidegger
-}
 \seealso{
 \code{jsonlite}
 }
+\author{
+Carlos Scheidegger
+}
 \keyword{github-package}
 \keyword{package}
-

--- a/man/interactive.login.Rd
+++ b/man/interactive.login.Rd
@@ -4,9 +4,15 @@
 \alias{interactive.login}
 \title{Obtain a github context interactively}
 \usage{
-interactive.login(client_id = NULL, client_secret = NULL, scopes = NULL,
-  base_url = "https://github.com", api_url = "https://api.github.com",
-  max_etags = 10000, verbose = FALSE)
+interactive.login(
+  client_id = NULL,
+  client_secret = NULL,
+  scopes = NULL,
+  base_url = "https://github.com",
+  api_url = "https://api.github.com",
+  max_etags = 10000,
+  verbose = FALSE
+)
 }
 \arguments{
 \item{client_id}{the github client ID}
@@ -42,4 +48,3 @@ or the feature might need to be removed.
 
 Refer to \url{http://developer.github.com/guides/basics-of-authentication/}
 }
-

--- a/man/is.assignee.Rd
+++ b/man/is.assignee.Rd
@@ -21,4 +21,3 @@ TRUE if user is assignee
 \description{
 Test if user is assignee in a repo
 }
-

--- a/man/is.member.in.team.Rd
+++ b/man/is.member.in.team.Rd
@@ -19,4 +19,3 @@ TRUE if user is member of team
 \description{
 test if user is a member of team
 }
-

--- a/man/is.member.of.organization.Rd
+++ b/man/is.member.of.organization.Rd
@@ -19,4 +19,3 @@ TRUE if user is a member of organization
 \description{
 test if user is a member of an organization
 }
-

--- a/man/is.public.member.of.organization.Rd
+++ b/man/is.public.member.of.organization.Rd
@@ -19,4 +19,3 @@ TRUE if user is a public member of organization
 \description{
 test if user is a public member of organization
 }
-

--- a/man/is.pull.request.merged.Rd
+++ b/man/is.pull.request.merged.Rd
@@ -21,4 +21,3 @@ TRUE if pull request has been merged
 \description{
 test if pull request has been merged
 }
-

--- a/man/is.repository.collaborator.Rd
+++ b/man/is.repository.collaborator.Rd
@@ -21,4 +21,3 @@ TRUE if user is a collaborator in the repo
 \description{
 test if a given user is a collaborator of a repo
 }
-

--- a/man/is.repository.starred.by.me.Rd
+++ b/man/is.repository.starred.by.me.Rd
@@ -19,4 +19,3 @@ TRUE if current user starred repo
 \description{
 check if repository is starred by current user
 }
-

--- a/man/is.starred.Rd
+++ b/man/is.starred.Rd
@@ -17,4 +17,3 @@ TRUE if gist is starred
 \description{
 test if gist is starred
 }
-

--- a/man/mark.my.notifications.Rd
+++ b/man/mark.my.notifications.Rd
@@ -17,4 +17,3 @@ None
 \description{
 mark my notifications as read
 }
-

--- a/man/mark.my.repository.notifications.Rd
+++ b/man/mark.my.repository.notifications.Rd
@@ -21,4 +21,3 @@ none
 \description{
 mark my notifications as read for a given repo
 }
-

--- a/man/mark.thread.notifications.Rd
+++ b/man/mark.thread.notifications.Rd
@@ -17,4 +17,3 @@ none
 \description{
 mark a single thread as read.
 }
-

--- a/man/modify.commit.comment.Rd
+++ b/man/modify.commit.comment.Rd
@@ -23,4 +23,3 @@ the comment
 \description{
 update a single commit comment
 }
-

--- a/man/modify.gist.Rd
+++ b/man/modify.gist.Rd
@@ -19,4 +19,3 @@ the new gist
 \description{
 Edit a gist
 }
-

--- a/man/modify.gist.comment.Rd
+++ b/man/modify.gist.comment.Rd
@@ -21,4 +21,3 @@ the comment
 \description{
 Edit gist comment
 }
-

--- a/man/modify.hook.Rd
+++ b/man/modify.hook.Rd
@@ -23,4 +23,3 @@ the specific hook
 \description{
 modify an exisitng hook for repo
 }
-

--- a/man/modify.issue.Rd
+++ b/man/modify.issue.Rd
@@ -23,4 +23,3 @@ the list of issues
 \description{
 Modify issue
 }
-

--- a/man/modify.issue.comment.Rd
+++ b/man/modify.issue.comment.Rd
@@ -4,8 +4,14 @@
 \alias{modify.issue.comment}
 \title{Modify issue comment}
 \usage{
-modify.issue.comment(owner, repo, issue.number, comment.number, content,
-  ctx = get.github.context())
+modify.issue.comment(
+  owner,
+  repo,
+  issue.number,
+  comment.number,
+  content,
+  ctx = get.github.context()
+)
 }
 \arguments{
 \item{owner}{the repo owner}
@@ -26,4 +32,3 @@ the comment
 \description{
 Modify issue comment
 }
-

--- a/man/modify.key.Rd
+++ b/man/modify.key.Rd
@@ -19,4 +19,3 @@ the updated public key
 \description{
 Update a public key with some id
 }
-

--- a/man/modify.milestone.Rd
+++ b/man/modify.milestone.Rd
@@ -4,8 +4,13 @@
 \alias{modify.milestone}
 \title{Edit milestone}
 \usage{
-modify.milestone(owner, repo, milestone.number, content,
-  ctx = get.github.context())
+modify.milestone(
+  owner,
+  repo,
+  milestone.number,
+  content,
+  ctx = get.github.context()
+)
 }
 \arguments{
 \item{owner}{the repo owner}
@@ -24,4 +29,3 @@ the created milestone
 \description{
 Edit milestone
 }
-

--- a/man/modify.myself.Rd
+++ b/man/modify.myself.Rd
@@ -18,4 +18,3 @@ Updated information about the user
 \description{
 Change information about the current user
 }
-

--- a/man/modify.organization.Rd
+++ b/man/modify.organization.Rd
@@ -19,4 +19,3 @@ the organization information
 \description{
 modify an organization
 }
-

--- a/man/modify.pull.request.Rd
+++ b/man/modify.pull.request.Rd
@@ -23,4 +23,3 @@ the specific pull request
 \description{
 edit pull request
 }
-

--- a/man/modify.pull.request.comment.Rd
+++ b/man/modify.pull.request.comment.Rd
@@ -4,8 +4,13 @@
 \alias{modify.pull.request.comment}
 \title{Modify a comment on a pull request}
 \usage{
-modify.pull.request.comment(owner, repo, pull.id, content,
-  ctx = get.github.context())
+modify.pull.request.comment(
+  owner,
+  repo,
+  pull.id,
+  content,
+  ctx = get.github.context()
+)
 }
 \arguments{
 \item{owner}{the repo owner}
@@ -24,4 +29,3 @@ the comment
 \description{
 Modify a comment on a pull request
 }
-

--- a/man/modify.reference.Rd
+++ b/man/modify.reference.Rd
@@ -23,4 +23,3 @@ the created reference
 \description{
 edit a reference
 }
-

--- a/man/modify.repository.Rd
+++ b/man/modify.repository.Rd
@@ -21,4 +21,3 @@ the changed repository
 \description{
 modify repository
 }
-

--- a/man/modify.repository.key.Rd
+++ b/man/modify.repository.key.Rd
@@ -23,4 +23,3 @@ the new key
 \description{
 update a repository key
 }
-

--- a/man/modify.repository.label.Rd
+++ b/man/modify.repository.label.Rd
@@ -4,8 +4,7 @@
 \alias{modify.repository.label}
 \title{edit a specific label for a repository}
 \usage{
-modify.repository.label(owner, repo, name, content,
-  ctx = get.github.context())
+modify.repository.label(owner, repo, name, content, ctx = get.github.context())
 }
 \arguments{
 \item{owner}{the repo owner}
@@ -24,4 +23,3 @@ The given label
 \description{
 edit a specific label for a repository
 }
-

--- a/man/modify.team.Rd
+++ b/man/modify.team.Rd
@@ -19,4 +19,3 @@ team information
 \description{
 edit a team in an organization
 }
-

--- a/man/perform.merge.pull.request.Rd
+++ b/man/perform.merge.pull.request.Rd
@@ -23,4 +23,3 @@ none
 \description{
 merge a pull request
 }
-

--- a/man/perform.repository.merge.Rd
+++ b/man/perform.repository.merge.Rd
@@ -21,4 +21,3 @@ the resulting merge commit
 \description{
 perform a merge.
 }
-

--- a/man/publicize.member.of.organization.Rd
+++ b/man/publicize.member.of.organization.Rd
@@ -19,4 +19,3 @@ None
 \description{
 publicize user membership in an organization
 }
-

--- a/man/replace.issue.labels.Rd
+++ b/man/replace.issue.labels.Rd
@@ -4,8 +4,13 @@
 \alias{replace.issue.labels}
 \title{Replace all issue labels}
 \usage{
-replace.issue.labels(owner, repo, issue.number, content,
-  ctx = get.github.context())
+replace.issue.labels(
+  owner,
+  repo,
+  issue.number,
+  content,
+  ctx = get.github.context()
+)
 }
 \arguments{
 \item{owner}{the repo owner}
@@ -24,4 +29,3 @@ The new list of labels
 \description{
 Replace all issue labels
 }
-

--- a/man/search.code.Rd
+++ b/man/search.code.Rd
@@ -23,4 +23,3 @@ Search the Github API.
 search.code("octokit in:file extension:gemspec -repo:octokit/octokit.rb", sort="indexed")
 }
 }
-

--- a/man/search.issues.Rd
+++ b/man/search.issues.Rd
@@ -23,4 +23,3 @@ Search the Github API.
 search.issues("windows label:bug language:python state:open", sort="created", order="asc")
 }
 }
-

--- a/man/search.repositories.Rd
+++ b/man/search.repositories.Rd
@@ -23,4 +23,3 @@ Search the Github API.
 search.repositories("tetris language:assembly")
 }
 }
-

--- a/man/search.users.Rd
+++ b/man/search.users.Rd
@@ -23,4 +23,3 @@ Search the Github API.
 search.users("tom repos:>42 followers:>1000")
 }
 }
-

--- a/man/set.repository.subscription.Rd
+++ b/man/set.repository.subscription.Rd
@@ -21,4 +21,3 @@ subscription info
 \description{
 set repository subscription info
 }
-

--- a/man/set.thread.notifications.subscription.Rd
+++ b/man/set.thread.notifications.subscription.Rd
@@ -19,4 +19,3 @@ the response object
 \description{
 subscribes current user to a thread, or ignore thread. Subscribing to a thread is unnecessary if the user is already subscribed to the repository. Ignoring a thread will mute all future notifications (until you comment or get at-mentioned).
 }
-

--- a/man/star.gist.Rd
+++ b/man/star.gist.Rd
@@ -17,4 +17,3 @@ none
 \description{
 star a gist
 }
-

--- a/man/star.repository.Rd
+++ b/man/star.repository.Rd
@@ -19,4 +19,3 @@ none
 \description{
 star a repository
 }
-

--- a/man/test.hook.Rd
+++ b/man/test.hook.Rd
@@ -21,4 +21,3 @@ none
 \description{
 test a push hook. This will force github to trigger the given hook.
 }
-

--- a/man/unfollow.user.Rd
+++ b/man/unfollow.user.Rd
@@ -17,4 +17,3 @@ none
 \description{
 Stop following a given user
 }
-

--- a/man/unset.repository.subscription.Rd
+++ b/man/unset.repository.subscription.Rd
@@ -19,4 +19,3 @@ subscription info
 \description{
 clear repository subscription info
 }
-

--- a/man/unset.thread.notifications.subscription.Rd
+++ b/man/unset.thread.notifications.subscription.Rd
@@ -17,4 +17,3 @@ none
 \description{
 deletes subscription info from thread.
 }
-

--- a/man/unstar.gist.Rd
+++ b/man/unstar.gist.Rd
@@ -17,4 +17,3 @@ none
 \description{
 unstar a gist
 }
-

--- a/man/unstar.repository.Rd
+++ b/man/unstar.repository.Rd
@@ -19,4 +19,3 @@ none
 \description{
 unstar a repository
 }
-

--- a/man/update.repository.path.Rd
+++ b/man/update.repository.path.Rd
@@ -4,8 +4,7 @@
 \alias{update.repository.path}
 \title{Update the contents of a file}
 \usage{
-\method{update}{repository.path}(owner, repo, path, ...,
-  ctx = get.github.context())
+\method{update}{repository.path}(owner, repo, path, ..., ctx = get.github.context())
 }
 \arguments{
 \item{owner}{the repo owner (user, org, etc)}
@@ -24,4 +23,3 @@ the file
 \description{
 Update the contents of a file
 }
-


### PR DESCRIPTION
@s-u wrote in email:
> the parameter name is a misnomer - it is not using basic authentication, it's using a token authorization (basic authentication is supported by GH, but has a different form and we're not using it), so I guess we should at least fix it for the parameter name - maybe turn it around and use github.use.query.token 

Also changing the default to TRUE, as I wrote:
> I would prefer if it defaulted to the github.com-compatible setting, however I don't think this is possible if we want old RCloud to work. For instance, install RCloud 2.0 and rgithub 0.9.10, and blamo! Obscure 403 errors because gist-services ended up in anonymous mode.
